### PR TITLE
Update AptosFramework revision

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -4,7 +4,7 @@ version = '0.1.1'
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = '985f19d40457a5f09f2d741b1feca6bf7ba1f8a6'
+rev = 'main'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [addresses]


### PR DESCRIPTION
Update `AptosFramework` revision to `main`, which is the same as https://github.com/pontem-network/liquidswap, this resolves issue #5 